### PR TITLE
Removed spaces from namespace groupings.

### DIFF
--- a/src/main/scala/com/gilt/gfc/aws/cloudwatch/periodic/metric/aggregator/CloudWatchMetricDataAggregatorBuilder.scala
+++ b/src/main/scala/com/gilt/gfc/aws/cloudwatch/periodic/metric/aggregator/CloudWatchMetricDataAggregatorBuilder.scala
@@ -56,7 +56,7 @@ case class CloudWatchMetricDataAggregatorBuilder private[metric] (
 
     val newNs = this.metricNamespace match {
       case None => ns
-      case Some(thisNs) => s"${thisNs} / ${ns}"
+      case Some(thisNs) => s"${thisNs}/${ns}"
     }
 
     this.copy(metricNamespace = Some(newNs))


### PR DESCRIPTION
Spaces are not allowed characters. I was very confused when the spaces were stripped out in AWS. 