### PR TITLE
Constructing the AmazonCloudWatchClient with the builder

### DIFF
--- a/src/main/scala/com/gilt/gfc/aws/cloudwatch/CloudWatchMetricsClient.scala
+++ b/src/main/scala/com/gilt/gfc/aws/cloudwatch/CloudWatchMetricsClient.scala
@@ -1,6 +1,6 @@
 package com.gilt.gfc.aws.cloudwatch
 
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatchClient, AmazonCloudWatchClientBuilder}
 import com.amazonaws.services.cloudwatch.model.{MetricDatum, PutMetricDataRequest}
 import com.gilt.gfc.concurrent.JavaConverters._
 import com.gilt.gfc.concurrent.{ExecutorService, SameThreadExecutionContext}
@@ -137,7 +137,7 @@ object CloudWatchMetricsClientImpl {
   val Logger = new OpenLoggable {}
 
   private
-  val awsClient = new AmazonCloudWatchClient()
+  val awsClient = AmazonCloudWatchClientBuilder.defaultClient()
 
 
   private


### PR DESCRIPTION
This PR makes it possible to configure the region via the standard mechanism (profile, env variables, etc)... The current version of the lib doesn't seem to be able to push custom metrics anywhere except `us-east-1`, the settings in `~/.aws/config` are being ignored.

One more thing, I've also tried to bump the `aws-java-sdk` to `1.11.217`, but it mysteriously brakes the `WorkQueueSpec` test, so not included that into the PR.

Please let me know if you plan to release a new version with this fix any time soon.